### PR TITLE
🔌 [自动同意加群] 更新至 v1.0.0

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -483,6 +483,20 @@
         "管理"
       ],
       "minVersion": "4.14.0"
+    },
+    {
+      "id": "napcat-plugin-group-invite-auto-approve",
+      "name": "自动同意加群",
+      "version": "1.0.0",
+      "description": "自动同意加群插件 - 根据群名称或群简介关键词自动同意加群邀请",
+      "author": "星陨",
+      "homepage": "https://github.com/XingYunStar/napcat-plugin-group-invite-auto-approve",
+      "downloadUrl": "https://github.com/XingYunStar/napcat-plugin-group-invite-auto-approve/releases/download/v1.0.0/napcat-plugin-group-invite-auto-approve.zip",
+      "tags": [
+        "工具",
+        "自动化"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-group-invite-auto-approve` |
| **插件名称** | 自动同意加群 |
| **版本** | v1.0.0 |
| **作者** | 星陨 |
| **下载链接** | https://github.com/XingYunStar/napcat-plugin-group-invite-auto-approve/releases/download/v1.0.0/napcat-plugin-group-invite-auto-approve.zip |
| **主页** | https://github.com/XingYunStar/napcat-plugin-group-invite-auto-approve |
| **最低版本** | 4.14.0 |

---

> 此 PR 由 CI 自动创建，来源: [XingYunStar/napcat-plugin-group-invite-auto-approve](https://github.com/XingYunStar/napcat-plugin-group-invite-auto-approve) Release v1.0.0