### PR TITLE
🔌 [ff14-market-house] 更新至 v0.1.2

### DIFF
--- a/plugins.v4.json
+++ b/plugins.v4.json
@@ -513,6 +513,20 @@
         "工具"
       ],
       "minVersion": "4.14.0"
+    },
+    {
+      "id": "napcat-plugin-ff14-market-house",
+      "name": "ff14-market-house",
+      "version": "0.1.2",
+      "description": "NapCat FF14 查价与查房插件",
+      "author": "sanxi",
+      "homepage": "https://github.com/sanxi33/napcat-plugin-ff14-market-house",
+      "downloadUrl": "https://github.com/sanxi33/napcat-plugin-ff14-market-house/releases/download/v0.1.2/napcat-plugin-ff14-market-house.zip",
+      "tags": [
+        "游戏",
+        "工具"
+      ],
+      "minVersion": "4.14.0"
     }
   ]
 }


### PR DESCRIPTION
## 🤖 自动更新插件索引

| 字段 | 值 |
|------|-----|
| **插件 ID** | `napcat-plugin-ff14-market-house` |
| **插件名称** | ff14-market-house |
| **版本** | v0.1.2 |
| **作者** | sanxi |
| **下载链接** | https://github.com/sanxi33/napcat-plugin-ff14-market-house/releases/download/v0.1.2/napcat-plugin-ff14-market-house.zip |
| **主页** | https://github.com/sanxi33/napcat-plugin-ff14-market-house |
| **最低版本** | 4.14.0 |